### PR TITLE
fix ios selected photo,  show error .

### DIFF
--- a/ios/Classes/NatCamera.m
+++ b/ios/Classes/NatCamera.m
@@ -11,6 +11,7 @@
 #import <AssetsLibrary/AssetsLibrary.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <Photos/Photos.h>
+#import "HooliURLProtocol.h"
 
 
 #define KOriginalPhotoImagePath   \
@@ -32,6 +33,7 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         manager = [[self alloc] init];
+        [NSURLProtocol registerClass:[HooliURLProtocol class]];
     });
     return manager;
 }


### PR DESCRIPTION
<Weex>[error]WXImageComponent.m:510, Error downloading image: nat://static/image/F50B782F-2446-4C1F-A63A-D9F6B22776EB/L0/001, detail:unsupported URL